### PR TITLE
Enable removing default env entries

### DIFF
--- a/lib/rack/test_app.rb
+++ b/lib/rack/test_app.rb
@@ -289,12 +289,16 @@ module Rack
         when /\Arack\./
           # ok
         when /\A[A-Z]+(_[A-Z0-9]+)*\z/
-          value.is_a?(String)  or
+          value.is_a?(String) || value.nil?  or
             raise ArgumentError.new("rack env value should be a string but got: #{value.inspect}")
         else
           raise ArgumentError.new("invalid rack env key: #{name}")
         end
-        environ[name] = value
+        if value.nil?
+          environ.delete(name)
+        else
+          environ[name] = value
+        end
       end if env
       #; [!pmefk] sets 'HTTP_COOKIE' when 'cookie' kwarg specified.
       if cookies

--- a/test/rack/test_app/TestApp_test.rb
+++ b/test/rack/test_app/TestApp_test.rb
@@ -206,6 +206,14 @@ describe Rack::TestApp do
       assert_equal expected, env['rack.session']
     end
 
+    it 'allows removing environ entries' do
+      environ = {
+        'CONTENT_LENGTH' => nil
+      }
+      env = Rack::TestApp.new_env(:PUT, '/', env: environ)
+      refute_includes env.keys, "CONTENT_LENGTH"
+    end
+
     it "[!pmefk] sets 'HTTP_COOKIE' when 'cookie' kwarg specified." do
       env = Rack::TestApp.new_env(cookies: 'c1=v1')
       assert_equal 'c1=v1', env['HTTP_COOKIE']


### PR DESCRIPTION
I needed to test how my app responds when "Content-Length" header missing (which is the case for `Transfer-Encoding: chunked` requests). For that I need the ability to remove default entries from the env hash. With this commit I can now do

```rb
app.post "/upload", input: "...", env: {"CONTENT_LENGTH" => nil}
```